### PR TITLE
It is idiomatic to take `impl AsyncRead` and `impl AsyncWrite` by value rather than by unique reference.

### DIFF
--- a/src/codec/byte.rs
+++ b/src/codec/byte.rs
@@ -4,7 +4,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Write the given byte into `writer`.
 /// In case of success, returns `1`
-pub async fn write_byte<W: AsyncWrite + Unpin>(byte: u8, writer: &mut W) -> SageResult<usize> {
+pub async fn write_byte<W: AsyncWrite + Unpin>(byte: u8, mut writer: W) -> SageResult<usize> {
     Ok(writer.write(&[byte]).await?)
 }
 
@@ -13,13 +13,13 @@ pub async fn write_byte<W: AsyncWrite + Unpin>(byte: u8, writer: &mut W) -> Sage
 /// with a byte being `0x00` for `false` or `0x01` for `false`. Other values are
 /// considered incorrect.
 /// In case of success, returns `1`
-pub async fn write_bool<W: AsyncWrite + Unpin>(data: bool, writer: &mut W) -> SageResult<usize> {
+pub async fn write_bool<W: AsyncWrite + Unpin>(data: bool, mut writer: W) -> SageResult<usize> {
     Ok(writer.write(&[data as u8]).await?)
 }
 
 /// Read the given `reader` for a byte value.
 /// In case of success, returns an `u8`
-pub async fn read_byte<R: AsyncRead + Unpin>(reader: &mut R) -> SageResult<u8> {
+pub async fn read_byte<R: AsyncRead + Unpin>(mut reader: R) -> SageResult<u8> {
     let mut buf = [0u8; 1];
     reader.read_exact(&mut buf).await?;
     Ok(buf[0])
@@ -30,7 +30,7 @@ pub async fn read_byte<R: AsyncRead + Unpin>(reader: &mut R) -> SageResult<u8> {
 /// with a byte being `0x00` for `false` or `0x01` for `false`. Other values are
 /// considered incorrect.
 /// In case of success, returns an `bool`
-pub async fn read_bool<R: AsyncRead + Unpin>(reader: &mut R) -> SageResult<bool> {
+pub async fn read_bool<R: AsyncRead + Unpin>(reader: R) -> SageResult<bool> {
     let byte = read_byte(reader).await?;
     match byte {
         0 => Ok(false),

--- a/src/codec/packet_type.rs
+++ b/src/codec/packet_type.rs
@@ -7,7 +7,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 /// In case of success, returns `1`.
 pub async fn write_control_packet_type<W: AsyncWrite + Unpin>(
     cpt: PacketType,
-    writer: &mut W,
+    writer: W,
 ) -> SageResult<usize> {
     codec::write_byte(
         match cpt {
@@ -40,7 +40,7 @@ pub async fn write_control_packet_type<W: AsyncWrite + Unpin>(
 /// Read the given `reader` for a `PacketType`.
 /// In case of success, returns a `PacketType` instance.
 pub async fn read_control_packet_type<R: AsyncRead + Unpin>(
-    reader: &mut R,
+    reader: R,
 ) -> SageResult<PacketType> {
     let packet_type = codec::read_byte(reader).await?;
     let packet_type = match (packet_type >> 4, packet_type & 0b0000_1111) {

--- a/src/codec/reason_code.rs
+++ b/src/codec/reason_code.rs
@@ -5,7 +5,7 @@ use tokio::io::AsyncWrite;
 ///Write the given `ReasonCode`in one byte, returning `1` in case of success.
 pub async fn write_reason_code<W: AsyncWrite + Unpin>(
     code: ReasonCode,
-    writer: &mut W,
+    writer: W,
 ) -> SageResult<usize> {
     codec::write_byte(
         match code {

--- a/src/control/connack.rs
+++ b/src/control/connack.rs
@@ -127,9 +127,9 @@ impl Default for ConnAck {
 }
 
 impl ConnAck {
-    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, writer: &mut W) -> SageResult<usize> {
-        let mut n_bytes = codec::write_bool(self.session_present, writer).await?;
-        n_bytes += codec::write_reason_code(self.reason_code, writer).await?;
+    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, mut writer: W) -> SageResult<usize> {
+        let mut n_bytes = codec::write_bool(self.session_present, &mut writer).await?;
+        n_bytes += codec::write_reason_code(self.reason_code, &mut writer).await?;
 
         let mut properties = Vec::new();
 
@@ -200,16 +200,16 @@ impl ConnAck {
             }
         }
 
-        n_bytes += codec::write_variable_byte_integer(properties.len() as u32, writer).await?;
+        n_bytes += codec::write_variable_byte_integer(properties.len() as u32, &mut writer).await?;
         writer.write_all(&properties).await?;
 
         Ok(n_bytes)
     }
 
-    pub(crate) async fn read<R: AsyncRead + Unpin>(reader: &mut R) -> SageResult<Self> {
-        let session_present = codec::read_bool(reader).await?;
+    pub(crate) async fn read<R: AsyncRead + Unpin>(mut reader: R) -> SageResult<Self> {
+        let session_present = codec::read_bool(&mut reader).await?;
 
-        let reason_code = codec::read_byte(reader).await?.try_into()?;
+        let reason_code = codec::read_byte(&mut reader).await?.try_into()?;
 
         let mut session_expiry_interval = None;
         let mut receive_maximum = DEFAULT_RECEIVE_MAXIMUM;

--- a/src/control/pubcomp.rs
+++ b/src/control/pubcomp.rs
@@ -45,8 +45,8 @@ impl Default for PubComp {
 }
 
 impl PubComp {
-    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, writer: &mut W) -> SageResult<usize> {
-        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, writer).await?;
+    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, mut writer: W) -> SageResult<usize> {
+        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, &mut writer).await?;
 
         let mut properties = Vec::new();
 
@@ -60,18 +60,18 @@ impl PubComp {
         if n_bytes == 2 && self.reason_code != ReasonCode::Success {
             Ok(2)
         } else {
-            n_bytes += codec::write_reason_code(self.reason_code, writer).await?;
-            n_bytes += codec::write_variable_byte_integer(properties.len() as u32, writer).await?;
+            n_bytes += codec::write_reason_code(self.reason_code, &mut writer).await?;
+            n_bytes += codec::write_variable_byte_integer(properties.len() as u32, &mut writer).await?;
             writer.write_all(&properties).await?;
             Ok(n_bytes)
         }
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        mut reader: R,
         shortened: bool,
     ) -> SageResult<Self> {
-        let packet_identifier = codec::read_two_byte_integer(reader).await?;
+        let packet_identifier = codec::read_two_byte_integer(&mut reader).await?;
 
         let mut pubcomp = PubComp {
             packet_identifier,
@@ -81,9 +81,9 @@ impl PubComp {
         if shortened {
             pubcomp.reason_code = ReasonCode::Success;
         } else {
-            pubcomp.reason_code = codec::read_byte(reader).await?.try_into()?;
+            pubcomp.reason_code = codec::read_byte(&mut reader).await?.try_into()?;
 
-            let mut properties = PropertiesDecoder::take(reader).await?;
+            let mut properties = PropertiesDecoder::take(&mut reader).await?;
             while properties.has_properties() {
                 match properties.read().await? {
                     Property::ReasonString(v) => pubcomp.reason_string = Some(v),

--- a/src/control/publish.rs
+++ b/src/control/publish.rs
@@ -144,7 +144,7 @@ impl Publish {
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: R,
         duplicate: bool,
         qos: QoS,
         retain: bool,

--- a/src/control/pubrec.rs
+++ b/src/control/pubrec.rs
@@ -45,8 +45,8 @@ impl Default for PubRec {
 }
 
 impl PubRec {
-    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, writer: &mut W) -> SageResult<usize> {
-        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, writer).await?;
+    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, mut writer: W) -> SageResult<usize> {
+        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, &mut writer).await?;
 
         let mut properties = Vec::new();
 
@@ -60,18 +60,18 @@ impl PubRec {
         if n_bytes == 2 && self.reason_code != ReasonCode::Success {
             Ok(2)
         } else {
-            n_bytes += codec::write_reason_code(self.reason_code, writer).await?;
-            n_bytes += codec::write_variable_byte_integer(properties.len() as u32, writer).await?;
+            n_bytes += codec::write_reason_code(self.reason_code, &mut writer).await?;
+            n_bytes += codec::write_variable_byte_integer(properties.len() as u32, &mut writer).await?;
             writer.write_all(&properties).await?;
             Ok(n_bytes)
         }
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        mut reader: R,
         shortened: bool,
     ) -> SageResult<Self> {
-        let packet_identifier = codec::read_two_byte_integer(reader).await?;
+        let packet_identifier = codec::read_two_byte_integer(&mut reader).await?;
 
         let mut pubrec = PubRec {
             packet_identifier,
@@ -81,9 +81,9 @@ impl PubRec {
         if shortened {
             pubrec.reason_code = ReasonCode::Success;
         } else {
-            pubrec.reason_code = codec::read_byte(reader).await?.try_into()?;
+            pubrec.reason_code = codec::read_byte(&mut reader).await?.try_into()?;
 
-            let mut properties = PropertiesDecoder::take(reader).await?;
+            let mut properties = PropertiesDecoder::take(&mut reader).await?;
             while properties.has_properties() {
                 match properties.read().await? {
                     Property::ReasonString(v) => pubrec.reason_string = Some(v),

--- a/src/control/pubrel.rs
+++ b/src/control/pubrel.rs
@@ -45,8 +45,8 @@ impl Default for PubRel {
 }
 
 impl PubRel {
-    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, writer: &mut W) -> SageResult<usize> {
-        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, writer).await?;
+    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, mut writer: W) -> SageResult<usize> {
+        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, &mut writer).await?;
 
         let mut properties = Vec::new();
 
@@ -60,18 +60,18 @@ impl PubRel {
         if n_bytes == 2 && self.reason_code != ReasonCode::Success {
             Ok(2)
         } else {
-            n_bytes += codec::write_reason_code(self.reason_code, writer).await?;
-            n_bytes += codec::write_variable_byte_integer(properties.len() as u32, writer).await?;
+            n_bytes += codec::write_reason_code(self.reason_code, &mut writer).await?;
+            n_bytes += codec::write_variable_byte_integer(properties.len() as u32, &mut writer).await?;
             writer.write_all(&properties).await?;
             Ok(n_bytes)
         }
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        mut reader: R,
         shortened: bool,
     ) -> SageResult<Self> {
-        let packet_identifier = codec::read_two_byte_integer(reader).await?;
+        let packet_identifier = codec::read_two_byte_integer(&mut reader).await?;
 
         let mut pubrel = PubRel {
             packet_identifier,
@@ -81,9 +81,9 @@ impl PubRel {
         if shortened {
             pubrel.reason_code = ReasonCode::Success;
         } else {
-            pubrel.reason_code = codec::read_byte(reader).await?.try_into()?;
+            pubrel.reason_code = codec::read_byte(&mut reader).await?.try_into()?;
 
-            let mut properties = PropertiesDecoder::take(reader).await?;
+            let mut properties = PropertiesDecoder::take(&mut reader).await?;
             while properties.has_properties() {
                 match properties.read().await? {
                     Property::ReasonString(v) => pubrel.reason_string = Some(v),

--- a/src/control/subscribe.rs
+++ b/src/control/subscribe.rs
@@ -138,7 +138,7 @@ impl Subscribe {
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: R,
         remaining_size: usize,
     ) -> SageResult<Self> {
         let mut reader = reader.take(remaining_size as u64);

--- a/src/control/unsuback.rs
+++ b/src/control/unsuback.rs
@@ -37,8 +37,8 @@ impl Default for UnSubAck {
 }
 
 impl UnSubAck {
-    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, writer: &mut W) -> SageResult<usize> {
-        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, writer).await?;
+    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, mut writer: W) -> SageResult<usize> {
+        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, &mut writer).await?;
 
         let mut properties = Vec::new();
 
@@ -51,18 +51,18 @@ impl UnSubAck {
             n_bytes += Property::UserProperty(k, v).encode(&mut properties).await?;
         }
 
-        n_bytes += codec::write_variable_byte_integer(properties.len() as u32, writer).await?;
+        n_bytes += codec::write_variable_byte_integer(properties.len() as u32, &mut writer).await?;
         writer.write_all(&properties).await?;
 
         for reason_code in self.reason_codes {
-            n_bytes += codec::write_reason_code(reason_code, writer).await?;
+            n_bytes += codec::write_reason_code(reason_code, &mut writer).await?;
         }
 
         Ok(n_bytes)
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: R,
         remaining_size: usize,
     ) -> SageResult<Self> {
         let mut reader = reader.take(remaining_size as u64);

--- a/src/control/unsubscribe.rs
+++ b/src/control/unsubscribe.rs
@@ -27,25 +27,25 @@ impl Default for UnSubscribe {
 }
 
 impl UnSubscribe {
-    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, writer: &mut W) -> SageResult<usize> {
-        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, writer).await?;
+    pub(crate) async fn write<W: AsyncWrite + Unpin>(self, mut  writer: W) -> SageResult<usize> {
+        let mut n_bytes = codec::write_two_byte_integer(self.packet_identifier, &mut writer).await?;
 
         let mut properties = Vec::new();
         for (k, v) in self.user_properties {
             n_bytes += Property::UserProperty(k, v).encode(&mut properties).await?;
         }
-        n_bytes += codec::write_variable_byte_integer(properties.len() as u32, writer).await?;
+        n_bytes += codec::write_variable_byte_integer(properties.len() as u32, &mut writer).await?;
         writer.write_all(&properties).await?;
 
         for option in self.subscriptions {
-            n_bytes += codec::write_utf8_string(&option, writer).await?;
+            n_bytes += codec::write_utf8_string(&option, &mut writer).await?;
         }
 
         Ok(n_bytes)
     }
 
     pub(crate) async fn read<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: R,
         remaining_size: usize,
     ) -> SageResult<Self> {
         let mut reader = reader.take(remaining_size as u64);


### PR DESCRIPTION
`AsyncRead` and `AsyncWrite` are defined for `&mut R where R: AsyncRead` and `&mut W where W: AsyncWrite`, so there is no need to accept those by mutable reference.